### PR TITLE
Dual backdrop fix

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/fragments/scripts.jspf
+++ b/src/main/webapp/WEB-INF/jsp/fragments/scripts.jspf
@@ -1,6 +1,6 @@
 <section th:fragment="scripts">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>

--- a/src/main/webapp/WEB-INF/jsp/ticketsAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ticketsAdmin.jsp
@@ -132,11 +132,6 @@
     <%@include file="fragments/footer.jspf"%>
     <%@include file="fragments/scripts.jspf"%>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 <script type="text/javascript">
     $(document).ready(function() {
         // Cancel or change tickets


### PR DESCRIPTION
Fixed dual backdrop issue.

Jquery library of different versions was included twice. It resulted in creating two modal backdrops making it impossible to remove both in the admin page after the ticket was selected in cancel\change ticket modal

```
<div class="modal-backdrop show"></div>
<div class="modal-backdrop show"></div>
```